### PR TITLE
Run grub inside chroot, with explicit target

### DIFF
--- a/qemu-debian-create-image
+++ b/qemu-debian-create-image
@@ -169,7 +169,7 @@ sed -i "s|${DISK}p2|/dev/${DISKNAME}2|g" $MNT_DIR/boot/grub/grub.cfg
 echo "root:${ROOTPASSWD}" | chroot $MNT_DIR chpasswd
 
 echo "Finishing grub installation..."
-grub-install $DISK --root-directory=$MNT_DIR --modules="biosdisk part_msdos" || fail "cannot reinstall grub"
+chroot $MNT_DIR grub-install $DISK --modules="biosdisk part_msdos" --target=i386-pc || fail "cannot reinstall grub"
 
 echo "SUCCESS!"
 clean_debian


### PR DESCRIPTION
Run grub *inside* the `chroot` rather than outside, so that it is possible to install with a different `grub` target than is used on the host (eg, `i386-pc` BIOS boot rather than EFI); explicitly specify the default target (`i386-pc`) to avoid auto-detecting "same as host" which may not work.